### PR TITLE
builtins support (sketched w examples), count (partly working)

### DIFF
--- a/src/bdd.h
+++ b/src/bdd.h
@@ -206,6 +206,14 @@ public:
 	}
 
 	inline static uint_t var(int_t x) { return abs(V[abs(x)].v); }
+
+	static size_t satcount_perm(int_t x, size_t leafvar);
+	static size_t satcount_perm(const bdd& bx, int_t x, size_t leafvar);
+
+	static size_t getvar(int_t h, int_t l, int_t v, int_t x, size_t maxv);
+	static size_t satcount(int_t x);
+	static size_t satcount(const bdd& bx, int_t x, size_t leafvar,
+		std::map<int_t, int_t>& mapvars);
 };
 
 class bdd_handle {

--- a/src/dict.cpp
+++ b/src/dict.cpp
@@ -64,6 +64,14 @@ int_t dict_t::get_sym(const lexeme& l) {
 	return syms.push_back(l), syms_dict[l] = (syms.size()-1)<<2;
 }
 
+int_t dict_t::get_bltin(const lexeme& l) {
+	if (*l[0] == L'?') parse_error(err_var_relsym, l);
+	auto it = bltins_dict.find(l);
+	if (it != bltins_dict.end()) return it->second;
+	bltins.push_back(l);
+	return bltins_dict[l] = bltins.size() - 1;
+}
+
 lexeme dict_t::get_lexeme(const wstring& s) {
 	DBG(assert(!s.empty());)
 	cws w = s.c_str();

--- a/src/dict.h
+++ b/src/dict.h
@@ -10,37 +10,45 @@
 // from the Author (Ohad Asor).
 // Contact ohad@idni.org for requesting a permission. This license may be
 // modified over time by the Author.
+#ifndef __DICT_H__
+#define __DICT_H__
 #include "defs.h"
 #include <map>
 
 class dict_t {
 	typedef std::map<lexeme, int_t, lexcmp> dictmap;
-	dictmap syms_dict, vars_dict, rels_dict;
-	std::vector<lexeme> syms, rels;
+	dictmap syms_dict, vars_dict, rels_dict, bltins_dict;
+	std::vector<lexeme> syms, rels, bltins;
 	std::set<lexeme, lexcmp> strs_extra;
 public:
 	dict_t();
-	dict_t(const dict_t& d) : syms_dict(d.syms_dict),
-		vars_dict(d.vars_dict), rels_dict(d.rels_dict), syms(d.syms),
-		rels(d.rels), strs_extra(d.strs_extra), op(d.op), cl(d.cl) {}
+	dict_t(const dict_t& d) : syms_dict(d.syms_dict), vars_dict(d.vars_dict),
+		rels_dict(d.rels_dict), bltins_dict(d.bltins_dict), syms(d.syms),
+		rels(d.rels), bltins(d.bltins), strs_extra(d.strs_extra), op(d.op), 
+		cl(d.cl) {}
 	lexeme op, cl;
 	const lexeme& get_rel(int_t t) const { return rels[t]; }
+	const lexeme& get_bltin(int_t t) const { return bltins[t]; }
 	lexeme get_sym(int_t t) const;
 	int_t get_var(const lexeme& l);
 	int_t get_rel(const lexeme& l);
 	int_t get_sym(const lexeme& l);
+	int_t get_bltin(const lexeme& l);
 	int_t get_fresh_sym( int_t old);
 	int_t get_fresh_var( int_t old);
 	lexeme get_lexeme(const std::wstring& s);
 	int_t get_rel(const std::wstring& s) { return get_rel(get_lexeme(s)); }
+	int_t get_bltin(const std::wstring& s) { return get_bltin(get_lexeme(s)); }
 	size_t nsyms() const { return syms.size(); }
 	size_t nvars() const { return vars_dict.size(); }
 	size_t nrels() const { return rels.size(); }
+	size_t nbltins() const { return bltins.size(); }
 	dict_t& operator=(const dict_t& d) {
 		return syms_dict = d.syms_dict, vars_dict = d.vars_dict,
-			rels_dict = d.rels_dict, syms = d.syms,
-			rels = d.rels, strs_extra = d.strs_extra, op = d.op,
-			cl = d.cl, *this;
+			rels_dict = d.rels_dict, bltins_dict = d.bltins_dict, syms = d.syms,
+			rels = d.rels, bltins = d.bltins, strs_extra = d.strs_extra, 
+			op = d.op, cl = d.cl, *this;
 	}
 	~dict_t();
 };
+#endif // __DICT_H__

--- a/src/err.h
+++ b/src/err.h
@@ -43,3 +43,8 @@ const wchar_t err_rel_expected[] = L"Expected relation symbol.";
 const wchar_t err_len[] = L"Taking the length of an unknown string.";
 const wchar_t err_comment[] = L"Unfinished comment.";
 const wchar_t err_eof[] = L"Unexpected end of file.";
+const wchar_t err_eq_expected[] = L"Expected =/!= in the middle of term.";
+const wchar_t err_leq_expected[] = L"Expected <=/> in the middle of term.";
+const wchar_t err_3_els_expected[] = L"Expected 3 elements in the term.";
+const wchar_t err_builtin_expected[] = L"Expected builtin name in the beginning of term.";
+

--- a/src/term.h
+++ b/src/term.h
@@ -13,15 +13,18 @@
 #include "defs.h"
 
 struct term : public ints {
-	bool neg = false, goal = false, iseq = false, isleq = false;
+	bool neg = false, goal = false; // , iseq = false, isleq = false, isbltin;
+	enum textype { REL, EQ, LEQ, BLTIN } extype = term::REL;
 	ntable tab = -1;
+	size_t orderid = 0;
 	term() {}
-	term(bool neg, bool eq, bool isleq, ntable tab, const ints& args) :
-		ints(args), neg(neg), iseq(eq), isleq(isleq), tab(tab) {}
+	term(bool neg, textype extype, ntable tab, const ints& args, size_t orderid) 
+		: ints(args), neg(neg), extype(extype), tab(tab), orderid(orderid) {}
 	bool operator<(const term& t) const {
 		if (neg != t.neg) return neg;
-		if (iseq != t.iseq) return iseq; // why not compare?
-		if (isleq != t.isleq) return isleq;
+		//if (iseq != t.iseq) return iseq;
+		//if (isleq != t.isleq) return isleq;
+		//if (extype != t.extype) return extype < t.extype;
 		if (tab != t.tab) return tab < t.tab;
 		if (goal != t.goal) return goal;
 		return (const ints&)*this < t;

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -88,8 +88,8 @@ set<raw_rule> driver::refresh_vars(raw_rule& r) {
 };*/
 
 raw_term driver::from_grammar_elem(const elem& v, int_t v1, int_t v2) {
-	return { false, false, false, {
-        v, elem_openp, get_var_elem(v1), get_var_elem(v2), elem_closep}, {2}};
+	return { false, false, false, false, {
+		v, elem_openp, get_var_elem(v1), get_var_elem(v2), elem_closep}, {2}};
 }
 
 raw_term driver::from_grammar_elem_nt(const lexeme& r, const elem& c,
@@ -111,7 +111,7 @@ raw_term driver::from_grammar_elem_nt(const lexeme& r, const elem& c,
 
 raw_term driver::from_grammar_elem_builtin(const lexeme& r, const wstring& b,
 	int_t v){
-	return { false, false, false, {
+	return { false, false, false, false, {
 		elem(elem::SYM, r),
 		elem_openp, elem(elem::SYM, get_lexeme(b)),
 		get_var_elem(v), get_var_elem(v+1), elem_closep}, {3}};


### PR DESCRIPTION
...count (bdd issues pending), term flags slightly improved. Couple small 'breaking changes', in input 'prog' / dict is saved in one place and passed around (not ideal, but we need to improve on this, a start I guess). Also in tables, there's term_set instead of set<term... to allow for terms ordering in get_alt (that's needed for count to work on the 'previous' body, what I came up w/).